### PR TITLE
Apply abstract-only enrichment (fixes PDF abstracts being discarded)

### DIFF
--- a/papertrail/enrich_cascade.py
+++ b/papertrail/enrich_cascade.py
@@ -816,11 +816,15 @@ def enrich_papers_cascade(
 
     Returns the number of papers enriched.
     """
-    to_enrich = [
-        p for p in papers
-        if not p.get("title") or p["title"] in ("", "Untitled", "Unknown Title")
-    ]
-    logger.info("Enriching %d papers via cascade (%d already have titles)", len(to_enrich), len(papers) - len(to_enrich))
+    # Enrich papers that still lack BOTH a real title and an abstract. Having
+    # either means we already have usable content (e.g. a PDF-parsed abstract),
+    # so we skip them — that keeps the batch small and avoids re-downloading.
+    def _needs_enrichment(p: dict) -> bool:
+        has_title = p.get("title") and p["title"] not in ("", "Untitled", "Unknown Title")
+        return not has_title and not (p.get("abstract") or "").strip()
+
+    to_enrich = [p for p in papers if _needs_enrichment(p)]
+    logger.info("Enriching %d papers via cascade (%d already have content)", len(to_enrich), len(papers) - len(to_enrich))
 
     enriched = 0
     for i, paper in enumerate(to_enrich):
@@ -829,10 +833,16 @@ def enrich_papers_cascade(
             continue
 
         meta = enrich_url(url, email=email)
-        if meta.get("title") and meta["title"] not in ("", "Untitled", "Unknown Title"):
+        has_title = bool(meta.get("title")) and meta["title"] not in ("", "Untitled", "Unknown Title")
+        # Apply when we found a real title OR an abstract — abstract-only results
+        # (e.g. from PDF parsing) are valuable and must not be discarded.
+        if has_title or meta.get("abstract"):
             for k, v in meta.items():
-                if v is not None and v != "" and v != []:
-                    paper[k] = v
+                if v is None or v == "" or v == []:
+                    continue
+                if k == "title" and not has_title:
+                    continue  # never set a junk/empty title
+                paper[k] = v
             enriched += 1
 
         if delay:

--- a/papertrail/pipeline.py
+++ b/papertrail/pipeline.py
@@ -176,7 +176,10 @@ def run_pipeline(
     if existing_path.exists():
         with open(existing_path) as f:
             for p in json.load(f):
-                if p.get("url") and p.get("title"):
+                # Reuse any paper we previously got content for — a title OR an
+                # abstract (e.g. a PDF-parsed abstract on an otherwise untitled
+                # paper), so we don't re-download/re-enrich it every run.
+                if p.get("url") and (p.get("title") or (p.get("abstract") or "").strip()):
                     existing_by_url[p["url"]] = p
         logger.info("Loaded %d existing enriched papers for merge", len(existing_by_url))
 

--- a/tests/test_enrich_cascade.py
+++ b/tests/test_enrich_cascade.py
@@ -66,6 +66,29 @@ def test_ok_page_is_not_dead(monkeypatch):
     assert is_dead_link("https://example.com/paper") is False
 
 
+# --- cascade applies abstract-only enrichment (e.g. from PDF parsing) ----------
+
+def test_cascade_applies_abstract_even_without_title(monkeypatch):
+    monkeypatch.setattr(enrich_cascade, "enrich_url",
+                        lambda url, email="x": {"abstract": "Recovered from the PDF."})
+    papers = [{"url": "https://host/paper.pdf", "title": ""}]
+    n = enrich_cascade.enrich_papers_cascade(papers, delay=0)
+    assert n == 1
+    assert papers[0]["abstract"] == "Recovered from the PDF."
+    assert not papers[0].get("title")  # no junk title invented
+
+
+def test_cascade_skips_papers_that_already_have_an_abstract(monkeypatch):
+    calls = []
+    def fake(url, email="x"):
+        calls.append(url)
+        return {}
+    monkeypatch.setattr(enrich_cascade, "enrich_url", fake)
+    papers = [{"url": "https://host/x", "title": "", "abstract": "Already enriched."}]
+    enrich_cascade.enrich_papers_cascade(papers, delay=0)
+    assert calls == []  # not re-fetched — it already has content
+
+
 # --- URL-based fallback titles -------------------------------------------------
 
 def test_derive_title_arxiv():


### PR DESCRIPTION
## Summary
PR #149 added PDF parsing, but a verify run recovered **0** abstracts. Root cause: `enrich_papers_cascade` only wrote `enrich_url`'s result back when it contained a **title**, so PDF-parsed abstracts on untitled papers were silently discarded.

## Fix
- Apply enrichment when a real title **or** an abstract is found (never inventing a junk title).
- `to_enrich` skips papers that already have a title or abstract → small batch, no weekly re-downloads.
- Pipeline merge reuses title-or-abstract papers so PDF abstracts persist across runs.

Verified locally: PDF parsing recovers real abstracts (Denoising Diffusion, CVPR causal-signals, NeurIPS axiomatic-attribution). 54 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)