### PR TITLE
Fix OpenAlex title search (double-encoding) + affiliations + abstract search

### DIFF
--- a/papertrail/enrich_cascade.py
+++ b/papertrail/enrich_cascade.py
@@ -14,7 +14,7 @@ import logging
 import re
 import time
 from typing import Any, Optional
-from urllib.parse import urlparse, quote
+from urllib.parse import urlparse
 
 import requests
 
@@ -112,18 +112,28 @@ def _parse_pdf_abstract(text: str) -> str:
     return re.sub(r"\s+", " ", rest).strip()[:3000].strip()
 
 
-def _titles_match(a: str, b: str) -> bool:
-    """True if two titles share enough tokens to be the same paper.
+_TITLE_STOPWORDS = {
+    "the", "a", "an", "of", "for", "and", "in", "on", "to", "with", "via",
+    "using", "is", "are", "be", "from", "by", "at",
+}
 
-    Used to validate an unreliable PDF-extracted title against an OpenAlex hit
-    before adopting OpenAlex's (clean) metadata — guards against the title
-    search returning an unrelated paper for a garbage query.
+
+def _titles_match(a: str, b: str) -> bool:
+    """True if two titles are plausibly the same paper.
+
+    Uses Jaccard overlap (intersection / union) of content tokens, NOT
+    overlap/min — otherwise a short body fragment that happens to be a subset
+    of an unrelated title falsely matches (e.g. "the conflicting constraints"
+    matching "Conflicting constraints on the form of intertidal algae").
     """
-    ta = set(re.findall(r"[a-z0-9]+", (a or "").lower()))
-    tb = set(re.findall(r"[a-z0-9]+", (b or "").lower()))
+    def toks(s: str) -> set[str]:
+        return {t for t in re.findall(r"[a-z0-9]+", (s or "").lower())
+                if t not in _TITLE_STOPWORDS}
+
+    ta, tb = toks(a), toks(b)
     if not ta or not tb:
         return False
-    return len(ta & tb) / min(len(ta), len(tb)) >= 0.6
+    return len(ta & tb) / len(ta | tb) >= 0.6
 
 
 def extract_pdf_metadata(url: str) -> dict[str, Any]:
@@ -245,6 +255,15 @@ def enrich_url(url: str, email: str = "papertrail@example.com") -> dict[str, Any
                 result = {**result, **{k: v for k, v in oa.items() if v and not result.get(k)}}
         if result.get("title") and result.get("abstract"):
             logger.debug("Enriched via PDF parse: %s", url[:60])
+            return result
+
+    # Strategy 3c: We have an abstract but no title — find the paper in OpenAlex
+    # by full-text searching the abstract (validated by abstract overlap).
+    if result.get("abstract") and not result.get("title"):
+        oa = _lookup_openalex_by_abstract(result["abstract"], email)
+        if oa and oa.get("title"):
+            result = {**result, **{k: v for k, v in oa.items() if v and not result.get(k)}}
+            logger.debug("Enriched via abstract→OpenAlex: %s", url[:60])
             return result
 
     # Strategy 4: Google search as last resort
@@ -466,9 +485,11 @@ def _lookup_openalex_title(title: str, email: str) -> Optional[dict]:
     """Search OpenAlex by title."""
     try:
         headers = {**HEADERS, "User-Agent": f"PaperTrail/1.0 (mailto:{email})"}
+        # NOTE: pass the title as raw text — requests URL-encodes params itself.
+        # Pre-quoting here double-encodes spaces (%20 → %2520) and matches nothing.
         resp = requests.get(
             "https://api.openalex.org/works",
-            params={"filter": f"title.search:{quote(title[:100], safe='')}", "per_page": 1},
+            params={"filter": f"title.search:{title[:100]}", "per_page": 1},
             headers=headers, timeout=10,
         )
         if resp.ok:
@@ -478,6 +499,46 @@ def _lookup_openalex_title(title: str, email: str) -> Optional[dict]:
     except Exception as e:
         logger.debug("OpenAlex title search failed: %s", e)
     return None
+
+
+def _lookup_openalex_by_abstract(abstract: str, email: str) -> Optional[dict]:
+    """Find a paper via OpenAlex full-text search on a distinctive abstract snippet.
+
+    Full-text search returns topically-similar papers, so the hit is only
+    accepted when its abstract has high token overlap with ours — otherwise a
+    different paper on the same topic would be wrongly adopted.
+    """
+    snippet = " ".join((abstract or "").split()[:30])
+    if len(snippet) < 40:
+        return None
+    try:
+        headers = {**HEADERS, "User-Agent": f"PaperTrail/1.0 (mailto:{email})"}
+        resp = requests.get(
+            "https://api.openalex.org/works",
+            params={"search": snippet, "per_page": 1},
+            headers=headers, timeout=10,
+        )
+        if resp.ok:
+            results = resp.json().get("results", [])
+            if results:
+                parsed = _parse_openalex(results[0])
+                if parsed.get("abstract") and _abstracts_overlap(abstract, parsed["abstract"]):
+                    return parsed
+    except Exception as e:
+        logger.debug("OpenAlex abstract search failed: %s", e)
+    return None
+
+
+def _abstracts_overlap(a: str, b: str) -> bool:
+    """True if two abstracts are the same text (high content-token Jaccard)."""
+    def toks(s: str) -> set[str]:
+        return {t for t in re.findall(r"[a-z0-9]+", (s or "").lower())
+                if t not in _TITLE_STOPWORDS}
+
+    ta, tb = toks(a), toks(b)
+    if not ta or not tb:
+        return False
+    return len(ta & tb) / len(ta | tb) >= 0.55
 
 
 def _lookup_biorxiv_api(doi: str) -> Optional[dict]:
@@ -616,6 +677,14 @@ def _parse_openalex(data: dict) -> dict[str, Any]:
         for a in data.get("authorships", [])
     ]
 
+    # De-duplicated institutional affiliations across all authors (order-preserving)
+    affiliations = list(dict.fromkeys(
+        inst.get("display_name", "")
+        for a in data.get("authorships", [])
+        for inst in a.get("institutions", [])
+        if inst.get("display_name")
+    ))
+
     journal = None
     primary_loc = data.get("primary_location") or {}
     if primary_loc:
@@ -635,6 +704,7 @@ def _parse_openalex(data: dict) -> dict[str, Any]:
     return {
         "title": title,
         "authors": authors,
+        "affiliations": affiliations,
         "year": data.get("publication_year"),
         "journal": journal,
         "abstract": abstract,

--- a/tests/test_openalex.py
+++ b/tests/test_openalex.py
@@ -1,0 +1,86 @@
+"""Tests for OpenAlex parsing + title-search query construction."""
+
+from papertrail import enrich_cascade
+from papertrail.enrich_cascade import (
+    _lookup_openalex_by_abstract,
+    _lookup_openalex_title,
+    _parse_openalex,
+)
+
+
+def test_parse_openalex_extracts_authors_and_affiliations():
+    data = {
+        "title": "A Paper",
+        "publication_year": 2024,
+        "cited_by_count": 42,
+        "authorships": [
+            {"author": {"display_name": "Ada Lovelace"},
+             "institutions": [{"display_name": "MIT"}]},
+            {"author": {"display_name": "Alan Turing"},
+             "institutions": [{"display_name": "MIT"}, {"display_name": "Stanford"}]},
+        ],
+    }
+    r = _parse_openalex(data)
+    assert r["authors"] == ["Ada Lovelace", "Alan Turing"]
+    assert r["affiliations"] == ["MIT", "Stanford"]  # de-duped, order-preserving
+    assert r["cited_by_count"] == 42
+
+
+def test_openalex_title_search_is_not_double_encoded(monkeypatch):
+    """Regression: the title must reach the API as raw text, not pre-%-encoded.
+
+    Pre-quoting then letting requests encode again turned spaces into %2520
+    and matched nothing — silently breaking all title-based enrichment.
+    """
+    captured = {}
+
+    class _Resp:
+        ok = True
+
+        def json(self):
+            return {"results": [{"title": "Denoising Diffusion Probabilistic Models"}]}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured["params"] = params
+        return _Resp()
+
+    monkeypatch.setattr(enrich_cascade.requests, "get", fake_get)
+    _lookup_openalex_title("Denoising Diffusion Probabilistic Models", "e@x.org")
+
+    assert captured["params"]["filter"] == "title.search:Denoising Diffusion Probabilistic Models"
+    assert "%25" not in captured["params"]["filter"]
+    assert "%20" not in captured["params"]["filter"]
+
+
+OURS = ("We present high quality image synthesis results using diffusion probabilistic "
+        "models a class of latent variable models inspired by nonequilibrium thermodynamics")
+
+
+def _mock_openalex(monkeypatch, returned_abstract):
+    inv = {}
+    for i, w in enumerate(returned_abstract.split()):
+        inv.setdefault(w, []).append(i)
+
+    class _Resp:
+        ok = True
+
+        def json(self):
+            return {"results": [{"title": "Some Paper", "abstract_inverted_index": inv,
+                                 "authorships": [], "publication_year": 2020}]}
+
+    monkeypatch.setattr(enrich_cascade.requests, "get",
+                        lambda *a, **k: _Resp())
+
+
+def test_abstract_search_adopts_confident_match(monkeypatch):
+    _mock_openalex(monkeypatch, OURS)  # returned abstract == ours
+    r = _lookup_openalex_by_abstract(OURS, "e@x.org")
+    assert r and r.get("title") == "Some Paper"
+
+
+def test_abstract_search_rejects_topically_similar_mismatch(monkeypatch):
+    # A different diffusion paper — shares some jargon but is not the same abstract.
+    other = ("We introduce Palette a unified framework for image-to-image translation "
+             "based on conditional diffusion achieving strong results on colorization")
+    _mock_openalex(monkeypatch, other)
+    assert _lookup_openalex_by_abstract(OURS, "e@x.org") is None


### PR DESCRIPTION
## Summary
The root cause behind weak enrichment for papers without a clean DOI/arXiv ID: `_lookup_openalex_title` pre-`quote()`-ed the title and then let `requests` encode it **again** (`%20`→`%2520`), so **every title-based OpenAlex lookup matched nothing**. Only ID-based lookups worked.

This is the foundation of the intended strategy — *extract a title (page/PDF/Google) → solid OpenAlex query → get authors, affiliations, citations, year, journal, abstract* — for **all** papers, not just PDFs.

## Changes
- **Fix title-search encoding**: pass the title as raw text (verified live — now returns the paper with authors + 5,640 citations + affiliations).
- **Capture affiliations**: `_parse_openalex` now extracts de-duped author institutions.
- **Jaccard matcher**: `_titles_match` uses overlap/union, not overlap/min — a short PDF body fragment no longer false-matches a longer unrelated title (was mapping a "Distilling the Knowledge…" PDF onto a 1991 algae paper).
- **Abstract search fallback** (`_lookup_openalex_by_abstract`): when we have an abstract but no title, full-text search by abstract snippet, **validated by abstract overlap** (full-text search returns topically-similar papers, so the hit must be confirmed).

60 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)