### PR TITLE
Fix double-encoding in fill_missing_metadata + backfill affiliations

### DIFF
--- a/papertrail/enricher.py
+++ b/papertrail/enricher.py
@@ -1027,7 +1027,7 @@ def enrich_paper(url: str, timeout: int = DEFAULT_TIMEOUT) -> dict[str, Any]:
 def fill_missing_metadata(
     papers: list[dict[str, Any]],
     email: str = "papertrail@example.com",
-    fields: tuple[str, ...] = ("abstract", "authors", "journal", "year", "cited_by_count"),
+    fields: tuple[str, ...] = ("abstract", "authors", "affiliations", "journal", "year", "cited_by_count"),
 ) -> int:
     """
     Fill missing metadata for a list of papers using OpenAlex title search.
@@ -1072,11 +1072,11 @@ def fill_missing_metadata(
                     timeout=10,
                 )
             else:
-                from urllib.parse import quote
-                safe_title = quote(title[:100], safe='')
+                # Pass the title as raw text — requests URL-encodes params itself.
+                # Pre-quoting double-encodes spaces (%20→%2520) and matches nothing.
                 resp = requests.get(
                     OPENALEX_API,
-                    params={"filter": f"title.search:{safe_title}", "per_page": 1},
+                    params={"filter": f"title.search:{title[:100]}", "per_page": 1},
                     headers=headers,
                     timeout=10,
                 )
@@ -1103,6 +1103,16 @@ def fill_missing_metadata(
             if "authors" in fields and not p.get("authors") and data.get("authorships"):
                 p["authors"] = [a["author"]["display_name"] for a in data["authorships"][:10]]
                 changed = True
+            if "affiliations" in fields and not p.get("affiliations") and data.get("authorships"):
+                affs = list(dict.fromkeys(
+                    inst.get("display_name", "")
+                    for a in data["authorships"]
+                    for inst in a.get("institutions", [])
+                    if inst.get("display_name")
+                ))
+                if affs:
+                    p["affiliations"] = affs
+                    changed = True
             if "abstract" in fields and not p.get("abstract") and data.get("abstract_inverted_index"):
                 inv = data["abstract_inverted_index"]
                 words: dict[int, str] = {}

--- a/tests/test_openalex.py
+++ b/tests/test_openalex.py
@@ -84,3 +84,34 @@ def test_abstract_search_rejects_topically_similar_mismatch(monkeypatch):
              "based on conditional diffusion achieving strong results on colorization")
     _mock_openalex(monkeypatch, other)
     assert _lookup_openalex_by_abstract(OURS, "e@x.org") is None
+
+
+def test_fill_missing_metadata_raw_title_and_affiliations(monkeypatch):
+    """The batch backfill must also pass raw titles and now fills affiliations."""
+    from papertrail import enricher
+
+    captured = {}
+
+    class _Resp:
+        ok = True
+
+        def json(self):
+            return {"results": [{
+                "publication_year": 2020,
+                "cited_by_count": 5,
+                "authorships": [{"author": {"display_name": "Ada Lovelace"},
+                                 "institutions": [{"display_name": "MIT"}]}],
+                "abstract_inverted_index": {"Hello": [0], "world": [1]},
+            }]}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured["params"] = params
+        return _Resp()
+
+    monkeypatch.setattr(enricher.requests, "get", fake_get)
+    papers = [{"title": "Some Real Paper Title", "url": "https://h/x", "authors": []}]
+    enricher.fill_missing_metadata(papers, email="e@x.org")
+
+    assert captured["params"]["filter"] == "title.search:Some Real Paper Title"
+    assert papers[0]["authors"] == ["Ada Lovelace"]
+    assert papers[0]["affiliations"] == ["MIT"]


### PR DESCRIPTION
Same `quote()` + requests double-encoding bug as #151, but in `fill_missing_metadata` — the batch step that backfills authors/abstract/year/journal/citations for already-titled papers. It has been a no-op for title-based lookups, which is why existing titled papers lack authors. Now it passes raw titles and also backfills affiliations, so each run incrementally repairs titled papers' metadata via OpenAlex (preserved by the incremental merge).

61 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
