### PR TITLE
Add Claude LLM enrichment fallback + re-validate caches

### DIFF
--- a/data/koolab/papers_final.json
+++ b/data/koolab/papers_final.json
@@ -5572,15 +5572,6 @@
       "papers-dl"
     ],
     "title": "Discrete Flow Maps",
-    "abstract": "The sequential nature of autoregressive next-token prediction imposes a fundamental speed limit on large language models. While continuous flow models offer a path to parallel generation, they traditionally demand expensive iterative integration. Flow Maps bypass this bottleneck by compressing generative trajectories into single-step mappings, theoretically enabling the generation of full text sequences from noise in a single forward pass. However, standard formulations rely on Euclidean regression losses that are geometrically ill-suited for discrete data. In this work, we resolve this conflict with Discrete Flow Maps, a framework that reconciles trajectory compression with the geometry of the probability simplex. We recast standard flow map training for the discrete domain, aligning the training dynamics with the discrete nature of language. Empirically, this strict geometric alignment allows our method to surpass previous state-of-the-art results in discrete flow modeling.",
-    "authors": [
-      "Potaptchik, Peter",
-      "Yim, Jason",
-      "Saravanan, Adhi",
-      "Holderrieth, Peter",
-      "Vanden-Eijnden, Eric",
-      "Albergo, Michael S."
-    ],
     "projections": {
       "pca": [
         -0.15797929465770721,
@@ -11574,15 +11565,6 @@
       "papers-dl"
     ],
     "title": "Distribution-Conditioned Transport",
-    "abstract": "Learning a transport model that maps a source distribution to a target distribution is a canonical problem in machine learning, but scientific applications increasingly require models that can generalize to source and target distributions unseen during training. We introduce distribution-conditioned transport (DCT), a framework that conditions transport maps on learned embeddings of source and target distributions, enabling generalization to unseen distribution pairs. DCT also allows semi-supervised learning for distributional forecasting problems: because it learns from arbitrary distribution pairs, it can leverage distributions observed at only one condition to improve transport prediction. DCT is agnostic to the underlying transport mechanism, supporting models ranging from flow matching to distributional divergence-based models (e.g. Wasserstein, MMD). We demonstrate the practical performance benefits of DCT on synthetic benchmarks and four applications in biology: batch effect transfer in single-cell genomics, perturbation prediction from mass cytometry data, learning clonal transcriptional dynamics in hematopoiesis, and modeling T-cell receptor sequence evolution.",
-    "authors": [
-      "Fishman, Nic",
-      "Gowri, Gokul",
-      "Fischer, Paolo L. B.",
-      "Zitnik, Marinka",
-      "Abudayyeh, Omar",
-      "Gootenberg, Jonathan"
-    ],
     "projections": {
       "pca": [
         -0.06763481348752975,
@@ -15223,12 +15205,6 @@
       "papers-dl"
     ],
     "title": "Power-Sex Beliefs",
-    "authors": [
-      "Kristine Chapleau",
-      "Debra L. Oswald"
-    ],
-    "year": 2011,
-    "journal": "PsycTESTS Dataset",
     "doi": "10.1037/t02865-000",
     "projections": {
       "pca": [
@@ -23946,12 +23922,6 @@
       "papers-dl"
     ],
     "title": "Recursive Language Models",
-    "abstract": "We study allowing large language models (LLMs) to process arbitrarily long prompts through the lens of inference-time scaling. We propose Recursive Language Models (RLMs), a general inference paradigm that treats long prompts as part of an external environment and allows the LLM to programmatically examine, decompose, and recursively call itself over snippets of the prompt. We find that RLMs can successfully process inputs up to two orders of magnitude beyond model context windows and, even for shorter prompts, dramatically outperform the quality of vanilla frontier LLMs and common long-context and coding scaffolds (e.g., on GPT-5 by a median across the evaluated benchmarks of $26\\%$ against compaction, $130\\%$ against CodeAct with sub-calls, and $13\\%$ against Claude Code) across four diverse long-context tasks while having comparable cost. At a small scale, we post-train the first model around the RLM. Our model, RLM-Qwen3-8B, outperforms the underlying Qwen3-8B model by $28.3\\%$ on average and even approaches the quality of vanilla GPT-5 on three long-context tasks. Code is available at https://github.com/alexzhang13/rlm.",
-    "authors": [
-      "Zhang, Alex L.",
-      "Kraska, Tim",
-      "Khattab, Omar"
-    ],
     "projections": {
       "pca": [
         -0.18765445053577423,
@@ -39520,14 +39490,6 @@
       "papers-dl"
     ],
     "title": "The Principles of Diffusion Models",
-    "abstract": "This book presents the core principles that have guided the development of diffusion models, tracing their origins and showing how diverse formulations arise from shared mathematical ideas. Diffusion modeling starts by defining a forward process that gradually corrupts data into noise, linking the data distribution to a simple prior through a continuum of intermediate distributions. The goal is to learn a reverse process that transforms noise back into data while recovering the same intermediates. We describe three complementary views. The variational view, inspired by variational autoencoders, sees diffusion as learning to remove noise step by step. The score-based view, rooted in energy-based modeling, learns the gradient of the evolving data distribution, indicating how to nudge samples toward more likely regions. The flow-based view, related to normalizing flows, treats generation as following a smooth path that moves samples from noise to data under a learned velocity field. These perspectives share a common backbone: a time-dependent velocity field whose flow transports a simple prior to the data. Sampling then amounts to solving a differential equation that evolves noise into data along a continuous trajectory. On this foundation, the book discusses guidance for controllable generation, efficient numerical solvers, and diffusion-motivated flow-map models that learn direct mappings between arbitrary times. It provides a conceptual and mathematically grounded understanding of diffusion models for readers with basic deep-learning knowledge.",
-    "authors": [
-      "Lai, Chieh-Hsin",
-      "Song, Yang",
-      "Kim, Dongjun",
-      "Mitsufuji, Yuki",
-      "Ermon, Stefano"
-    ],
     "projections": {
       "pca": [
         -0.18300095200538635,
@@ -44530,15 +44492,6 @@
       "papers-dl"
     ],
     "title": "The Diffusion Duality",
-    "abstract": "Uniform-state discrete diffusion models hold the promise of fast text generation due to their inherent ability to self-correct. However, they are typically outperformed by autoregressive models and masked diffusion models. In this work, we narrow this performance gap by leveraging a key insight: Uniform-state diffusion processes naturally emerge from an underlying Gaussian diffusion. Our method, Duo, transfers powerful techniques from Gaussian diffusion to improve both training and sampling. First, we introduce a curriculum learning strategy guided by the Gaussian process, doubling training speed by reducing variance. Models trained with curriculum learning surpass autoregressive models in zero-shot perplexity on 3 of 7 benchmarks. Second, we present Discrete Consistency Distillation, which adapts consistency distillation from the continuous to the discrete setting. This algorithm unlocks few-step generation in diffusion language models by accelerating sampling by two orders of magnitude. We provide the code, model checkpoints, and video tutorials on the project page: http://s-sahoo.github.io/duo",
-    "authors": [
-      "Sahoo, Subham Sekhar",
-      "Deschenaux, Justin",
-      "Gokaslan, Aaron",
-      "Wang, Guanghan",
-      "Chiu, Justin",
-      "Kuleshov, Volodymyr"
-    ],
     "projections": {
       "pca": [
         -0.20568232238292694,

--- a/papertrail/enrich_cascade.py
+++ b/papertrail/enrich_cascade.py
@@ -10,6 +10,7 @@ Strategy order:
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import time
@@ -172,6 +173,115 @@ def extract_pdf_metadata(url: str) -> dict[str, Any]:
     return out
 
 
+_LLM_PROMPT = (
+    "Extract bibliographic metadata from the text of a research paper, preprint, "
+    "or technical blog post / announcement below.\n\n"
+    "Respond with ONLY a JSON object (no markdown, no prose) of the form:\n"
+    '{"is_paper": bool, "title": str, "authors": [str], '
+    '"affiliations": [str], "abstract": str}\n\n'
+    "- abstract: the paper's abstract, or for a blog post a 1-3 sentence summary.\n"
+    "- Set is_paper=false if this is clearly NOT scholarly/technical content "
+    "(a pricing page, login page, legal notice, marketing page, error page, or "
+    "dataset/tool listing).\n"
+    "- Use only what is present in the text; never invent authors or affiliations. "
+    "Use empty arrays / empty string for anything absent.\n\n"
+    "DOCUMENT TEXT:\n"
+)
+
+
+def _parse_llm_json(raw: str) -> dict:
+    """Parse the model's reply into a dict, tolerating ```json fences/prose."""
+    s = (raw or "").strip()
+    m = re.search(r"\{.*\}", s, re.DOTALL)
+    if not m:
+        return {}
+    try:
+        return json.loads(m.group(0))
+    except json.JSONDecodeError:
+        return {}
+
+
+def _coerce_llm_meta(data: dict) -> dict[str, Any]:
+    """Turn Claude's structured extraction into our metadata dict (pure)."""
+    if not data or not data.get("is_paper"):
+        return {}
+    title = (data.get("title") or "").strip()
+    if not title:
+        return {}
+    out: dict[str, Any] = {"title": title}
+    authors = [a for a in (data.get("authors") or []) if a and a.strip()]
+    affiliations = [a for a in (data.get("affiliations") or []) if a and a.strip()]
+    abstract = (data.get("abstract") or "").strip()
+    if authors:
+        out["authors"] = authors
+    if affiliations:
+        out["affiliations"] = affiliations
+    if abstract:
+        out["abstract"] = abstract
+    return out
+
+
+def _fetch_text_for_llm(url: str) -> str:
+    """Fetch a URL and return plain text (PDF text or stripped HTML), capped."""
+    resp = requests.get(
+        url, timeout=20, allow_redirects=True,
+        headers={"User-Agent": "Mozilla/5.0 (PaperTrail/1.0)"},
+    )
+    if resp.status_code >= 400:
+        return ""
+    ctype = resp.headers.get("content-type", "").lower()
+    if "pdf" in ctype or _is_pdf_url(resp.url):
+        import fitz  # PyMuPDF
+
+        doc = fitz.open(stream=resp.content, filetype="pdf")
+        text = "\n".join(doc[i].get_text() for i in range(min(4, doc.page_count)))
+        doc.close()
+        return text
+    # HTML → text: drop scripts/styles and tags
+    html = resp.text
+    html = re.sub(r"(?is)<(script|style|noscript)[^>]*>.*?</\1>", " ", html)
+    return re.sub(r"<[^>]+>", " ", html)
+
+
+def _llm_extract_metadata(url: str, email: str = "papertrail@example.com") -> dict[str, Any]:
+    """Last-resort enrichment: have Claude read the page/PDF and extract metadata.
+
+    Gated on ANTHROPIC_API_KEY — returns {} (no network/model call) when unset,
+    so the pipeline runs fine without it. When a title is recovered, it's also
+    cross-checked against OpenAlex to pull in citations/year for indexed papers.
+    """
+    import os
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        return {}
+    try:
+        text = _fetch_text_for_llm(url)
+        if len(text.strip()) < 100:
+            return {}
+        import anthropic
+
+        client = anthropic.Anthropic()
+        resp = client.messages.create(
+            model="claude-haiku-4-5",
+            max_tokens=2048,
+            messages=[{"role": "user", "content": _LLM_PROMPT + text[:24000]}],
+        )
+        raw = next((b.text for b in resp.content if b.type == "text"), "")
+        meta = _coerce_llm_meta(_parse_llm_json(raw))
+    except Exception as e:  # noqa: BLE001 — never let the fallback abort enrichment
+        logger.debug("LLM extraction failed for %s: %s", url[:60], e)
+        return {}
+
+    # If we got a title, try OpenAlex for clean citations/year/journal (validated).
+    if meta.get("title"):
+        oa = _lookup_openalex_title(meta["title"], email)
+        if oa and oa.get("title") and _titles_match(meta["title"], oa["title"]):
+            for k, v in oa.items():
+                if v and not meta.get(k):
+                    meta[k] = v
+    return meta
+
+
 def enrich_url(url: str, email: str = "papertrail@example.com") -> dict[str, Any]:
     """
     Enrich a paper URL using a multi-strategy cascade.
@@ -275,6 +385,17 @@ def enrich_url(url: str, email: str = "papertrail@example.com") -> dict[str, Any
             if oa:
                 result = {**result, **{k: v for k, v in oa.items() if v and not result.get(k)}}
                 logger.debug("Enriched via Google→OpenAlex: %s", url[:60])
+
+    # Strategy 5: Claude reads the page/PDF directly (gated on ANTHROPIC_API_KEY).
+    # The robust last resort for content no deterministic method could resolve —
+    # blog posts, announcements, and PDFs whose layout defeats heuristic parsing.
+    if not result.get("title") or not result.get("abstract"):
+        llm = _llm_extract_metadata(url, email)
+        for k, v in llm.items():
+            if v and not result.get(k):
+                result[k] = v
+        if llm.get("title"):
+            logger.debug("Enriched via Claude fallback: %s", url[:60])
 
     # Final fallback: infer journal from URL domain
     if not result.get("journal"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "click>=8.1",
     "pyyaml>=6.0",
     "pymupdf>=1.24",
+    "anthropic>=0.40",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -1,0 +1,60 @@
+"""Tests for the Claude LLM enrichment fallback."""
+
+from papertrail import enrich_cascade
+from papertrail.enrich_cascade import (
+    _coerce_llm_meta,
+    _llm_extract_metadata,
+    _parse_llm_json,
+)
+
+
+def test_parse_llm_json_plain():
+    assert _parse_llm_json('{"is_paper": true, "title": "X"}') == {"is_paper": True, "title": "X"}
+
+
+def test_parse_llm_json_strips_fences_and_prose():
+    raw = 'Here you go:\n```json\n{"is_paper": false, "title": ""}\n```'
+    assert _parse_llm_json(raw) == {"is_paper": False, "title": ""}
+
+
+def test_parse_llm_json_garbage():
+    assert _parse_llm_json("not json at all") == {}
+
+
+def test_coerce_keeps_paper_fields():
+    data = {
+        "is_paper": True,
+        "title": "A Real Paper Title",
+        "authors": ["Ada Lovelace", "Alan Turing"],
+        "affiliations": ["MIT"],
+        "abstract": "We show something interesting.",
+    }
+    out = _coerce_llm_meta(data)
+    assert out["title"] == "A Real Paper Title"
+    assert out["authors"] == ["Ada Lovelace", "Alan Turing"]
+    assert out["affiliations"] == ["MIT"]
+    assert out["abstract"] == "We show something interesting."
+
+
+def test_coerce_drops_non_paper():
+    data = {"is_paper": False, "title": "Pricing — Acme Corp", "authors": [], "affiliations": [], "abstract": ""}
+    assert _coerce_llm_meta(data) == {}
+
+
+def test_coerce_drops_when_no_title():
+    data = {"is_paper": True, "title": "", "authors": ["X"], "affiliations": [], "abstract": "abc"}
+    assert _coerce_llm_meta(data) == {}
+
+
+def test_coerce_omits_empty_fields():
+    data = {"is_paper": True, "title": "T", "authors": [], "affiliations": [], "abstract": ""}
+    out = _coerce_llm_meta(data)
+    assert out == {"title": "T"}  # empty lists/strings dropped
+
+
+def test_llm_extract_skips_without_api_key(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    # Must not attempt any network/model call when the key is absent.
+    monkeypatch.setattr(enrich_cascade, "_fetch_text_for_llm",
+                        lambda url: (_ for _ in ()).throw(AssertionError("should not fetch")))
+    assert _llm_extract_metadata("https://host/x.pdf", "e@x.org") == {}


### PR DESCRIPTION
## Summary
Adds the final cascade tier you asked for: when no deterministic method (page scrape, DOI/arXiv/bioRxiv/PII, title→OpenAlex, PDF parse, abstract→OpenAlex, Google) yields a title/abstract, **Claude reads the page or PDF directly** and extracts title, authors, affiliations, and abstract.

This targets the content OpenAlex structurally can't resolve — research blogs, model/benchmark announcements, and PDFs whose layout defeats heuristic title extraction (~425 koolab + ~280 SMB papers).

## Design
- **Gated on `ANTHROPIC_API_KEY`** — returns `{}` with no network/model call when unset, so the pipeline runs unchanged without it.
- `_fetch_text_for_llm`: PDF (PyMuPDF) or stripped HTML → text; **Haiku 4.5** extracts JSON (`is_paper`, `title`, `authors`, `affiliations`, `abstract`).
- Prompt-based JSON + tolerant parse (not `output_config`) for robustness across `anthropic` SDK versions; whole call wrapped so a failure never aborts enrichment.
- A recovered title is **cross-checked against OpenAlex** (`_titles_match`) to pull citations/year for indexed works.
- Adds `anthropic` dependency.

## Also in this PR
- One-time **re-validation** of the committed caches: re-checked OpenAlex-sourced titles against each paper's title and cleared any that don't pass `_titles_match` (cleanup of pre-#153 unvalidated matches).

## Action required
Add `ANTHROPIC_API_KEY` to repo secrets to activate the tier in CI. `pipeline.yml` already passes it through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
