### PR TITLE
Fix outlier-cluster artifact (content-less papers collapsing)

### DIFF
--- a/papertrail/enrich_cascade.py
+++ b/papertrail/enrich_cascade.py
@@ -886,6 +886,31 @@ def clean_text_for_clustering(title: str, abstract: str, message: str) -> str:
     return ' '.join(parts)
 
 
+def clustering_text(paper: dict) -> str:
+    """Text used to embed/cluster a paper.
+
+    Content-less husks (no title/abstract, URL-only message) otherwise produce
+    an EMPTY clustering string — and every empty string embeds to the same point,
+    which UMAP/t-SNE fling to a far-off outlier island (the "Paper Reference" /
+    "Paper Sources" artifact). For those, fall back to the channel name (a strong
+    topical prior) plus a URL-derived slug (per-paper distinctness) so they land
+    near their real topic instead of collapsing.
+    """
+    text = clean_text_for_clustering(
+        paper.get("title", ""), paper.get("abstract", ""), paper.get("text", "")
+    )
+    if len(text.strip()) >= 6:
+        return text
+    channels = paper.get("channels") or ([paper["channel"]] if paper.get("channel") else [])
+    ch = " ".join(c.replace("-", " ").replace("_", " ") for c in channels if c)
+    # Tokenize the whole URL (domain + path + query) so papers whose only
+    # distinguishing id sits in the query string (e.g. openreview /pdf?id=XYZ)
+    # still get distinct text instead of collapsing to a shared slug.
+    parsed = urlparse(paper.get("url") or paper.get("paper_url") or "")
+    url_tokens = re.sub(r"[^a-z0-9]+", " ", f"{parsed.netloc} {parsed.path} {parsed.query}".lower()).strip()
+    return f"{ch} {url_tokens}".strip()
+
+
 def _clean_title(title: str) -> str:
     """Clean up a title string."""
     title = re.sub(r'\s+', ' ', title).strip()

--- a/papertrail/pipeline.py
+++ b/papertrail/pipeline.py
@@ -251,12 +251,11 @@ def run_pipeline(
         compute_projections_3d,
     )
 
-    from papertrail.enrich_cascade import clean_text_for_clustering
+    from papertrail.enrich_cascade import clustering_text
 
-    texts = [
-        clean_text_for_clustering(p.get("title", ""), p.get("abstract", ""), p.get("text", ""))
-        for p in all_papers
-    ]
+    # clustering_text falls back to channel + URL slug for content-less papers,
+    # so husks don't collapse to a degenerate embedding (the outlier-island artifact).
+    texts = [clustering_text(p) for p in all_papers]
 
     backend = config.get("embedding_backend", None)
     embeddings = embed_texts(texts, backend=backend)

--- a/tests/test_clustering_text.py
+++ b/tests/test_clustering_text.py
@@ -1,0 +1,33 @@
+"""Tests for clustering-text construction (outlier-artifact fix)."""
+
+from papertrail.enrich_cascade import clustering_text
+
+
+def test_real_content_used_directly():
+    p = {"title": "Denoising Diffusion Probabilistic Models",
+         "abstract": "We present high quality image synthesis results.",
+         "text": "", "url": "https://arxiv.org/abs/2006.11239",
+         "channel": "papers-dl"}
+    out = clustering_text(p)
+    assert "diffusion" in out.lower() and "synthesis" in out.lower()
+
+
+def test_husk_falls_back_to_channel_and_url_slug():
+    # No title/abstract, URL-only message — would otherwise be empty text.
+    p = {"title": "", "abstract": "", "text": "https://openreview.net/pdf?id=HJFVrpCaGE",
+         "url": "https://openreview.net/pdf?id=HJFVrpCaGE", "channels": ["papers-genomics"]}
+    out = clustering_text(p).lower()
+    assert "genomics" in out          # channel topical prior present
+    assert out.strip() != ""          # not degenerate
+
+
+def test_two_husks_in_different_channels_differ():
+    a = clustering_text({"title": "", "abstract": "", "text": "",
+                         "url": "https://x/a", "channels": ["papers-genomics"]})
+    b = clustering_text({"title": "", "abstract": "", "text": "",
+                         "url": "https://x/b", "channels": ["papers-ai-agents"]})
+    assert a != b  # no longer collapse to one identical string
+
+
+def test_husk_with_nothing_is_empty():
+    assert clustering_text({"title": "", "abstract": "", "text": "", "url": ""}) == ""


### PR DESCRIPTION
## Problem
Both dashboards show a far-off outlier island connected by long lines — labeled "Paper Reference" / "Paper Sources" / "Paper Info" (85 papers in koolab, 28 in SMB).

## Root cause
Husk papers (no title, no abstract, URL-only Slack message) yield an **empty** string from `clean_text_for_clustering` (it strips URLs + journal names). Every empty string embeds to the same point, which UMAP/t-SNE place as a degenerate far-flung island.

## Fix
`clustering_text(paper)`: when the cleaned text is empty, fall back to **channel name** (topical prior, e.g. `papers-genomics`) + **full URL tokens** (domain + path + query, for per-paper distinctness). Husks now embed near their real topic instead of collapsing.

Verified on current data: 85/85 koolab and 28/28 SMB husks now get distinct, non-empty clustering text (was all-empty → one island).

76 tests pass (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)