### PR TITLE
Recover biorxiv husks (DOI version + early-format)

### DIFF
--- a/papertrail/enrich_cascade.py
+++ b/papertrail/enrich_cascade.py
@@ -598,6 +598,14 @@ def _extract_ids(url: str) -> dict[str, str]:
         if m:
             ids["doi"] = m.group(1)
 
+        # bioRxiv/medRxiv "content/early/YYYY/MM/DD/YYYY.MM.DD.NNNNNN" (no 10.xxxx
+        # in the path) — reconstruct the DOI from the trailing date-id.
+        if re.search(r'bio[rx]xiv\.org|biorxiv\.org|medrxiv\.org', url, re.I):
+            m = re.search(r'/(\d{4}\.\d{2}\.\d{2}\.\d+)', url)
+            if m:
+                ids["doi"] = "10.1101/" + m.group(1)
+                ids["biorxiv_doi"] = ids["doi"]
+
     # arXiv ID
     arxiv_match = re.search(r'arxiv\.org/(?:abs|pdf)/(\d{4}\.\d{4,})', url, re.I)
     if arxiv_match:
@@ -626,18 +634,24 @@ def _clean_doi(doi: str) -> str:
 
 
 def _doi_candidates(doi: str):
-    """Yield the DOI then progressively shorter forms (drop trailing /segments).
+    """Yield the DOI and lookup-friendly variants.
 
-    Recovers DOIs the URL regex over-captured with a trailing page/path crumb
-    (OUP '10.1093/gigascience/giaf132/829' → '…/giaf132'), without guessing
-    which slash is the boundary — we just retry the lookup against each form.
+    - version-stripped: bioRxiv/arXiv URLs carry a version suffix
+      ('10.1101/2024.10.29.620913v2') that OpenAlex 404s — the indexed DOI is
+      versionless.
+    - progressively shorter: the URL regex over-captures a trailing page/path
+      crumb (OUP '10.1093/gigascience/giaf132/829' → '…/giaf132'); we retry
+      the lookup against each form rather than guess the boundary.
     """
-    yield doi
-    parts = doi.split('/')
-    # DOI = prefix '10.xxxx' + suffix; never trim below prefix + first suffix seg
-    while len(parts) > 2:
-        parts = parts[:-1]
-        yield '/'.join(parts)
+    seen: set[str] = set()
+    for base in (doi, re.sub(r'v\d+$', '', doi)):
+        parts = base.split('/')
+        while len(parts) >= 2:  # never trim below prefix '10.xxxx' + first suffix seg
+            cand = '/'.join(parts)
+            if cand and cand not in seen:
+                seen.add(cand)
+                yield cand
+            parts = parts[:-1]
 
 
 def _lookup_openalex_doi(doi: str, email: str) -> Optional[dict]:

--- a/tests/test_openalex.py
+++ b/tests/test_openalex.py
@@ -157,3 +157,16 @@ def test_extract_ids_cleans_doubled_science_url():
     from papertrail.enrich_cascade import _extract_ids
     ids = _extract_ids("https://www.science.org/doi/10.1126/science.abl4290https://www.science.org/doi/1")
     assert ids.get("doi") == "10.1126/science.abl4290"
+
+
+def test_doi_candidates_strips_version():
+    from papertrail.enrich_cascade import _doi_candidates
+    cands = list(_doi_candidates("10.1101/2024.10.29.620913v2"))
+    assert "10.1101/2024.10.29.620913" in cands  # versionless form tried
+
+
+def test_extract_ids_biorxiv_early_format():
+    from papertrail.enrich_cascade import _extract_ids
+    ids = _extract_ids("http://biorxiv.org/content/early/2023/10/26/2023.07.26.550653")
+    assert ids.get("doi") == "10.1101/2023.07.26.550653"
+    assert ids.get("biorxiv_doi") == "10.1101/2023.07.26.550653"


### PR DESCRIPTION
biorxiv was the largest husk group, none enriched. Two fixes: (1) strip DOI version suffix (v1/v2 — OpenAlex 404s on versioned DOIs) in _doi_candidates; (2) reconstruct DOIs from old 'content/early/YYYY/MM/DD/date-id' URLs that have no 10.xxxx in the path. Verified e2e — both formats now resolve real titles. 82 tests pass.