### PR TITLE
Use papertrail-portal.vercel.app as canonical dashboard URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ PaperTrail automatically discovers papers shared across your Slack workspace, en
 
 ### Live Demos
 
-- **Landing page** (lab picker): [papertrail-xi.vercel.app](https://papertrail-xi.vercel.app)
-- Koo Lab Dashboard — [Vercel](https://papertrail-xi.vercel.app/koolab/) · [GitHub Pages](https://bschilder.github.io/PaperTrail/koolab/)
-- Standard Model Bio Dashboard — [Vercel](https://papertrail-xi.vercel.app/standardmodelbio/) · [GitHub Pages](https://bschilder.github.io/PaperTrail/standardmodelbio/)
+- **Landing page** (lab picker): [papertrail-portal.vercel.app](https://papertrail-portal.vercel.app)
+- Koo Lab Dashboard — [Vercel](https://papertrail-portal.vercel.app/koolab/) · [GitHub Pages](https://bschilder.github.io/PaperTrail/koolab/)
+- Standard Model Bio Dashboard — [Vercel](https://papertrail-portal.vercel.app/standardmodelbio/) · [GitHub Pages](https://bschilder.github.io/PaperTrail/standardmodelbio/)
 
 [Documentation](https://bschilder.github.io/PaperTrail) · [Report Bug](https://github.com/bschilder/PaperTrail/issues) · [Request Feature](https://github.com/bschilder/PaperTrail/issues)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,9 @@ PaperTrail automatically discovers papers shared across your Slack workspace, en
 
 ### Live Demos
 
-- **Landing page** (lab picker): [papertrail-xi.vercel.app](https://papertrail-xi.vercel.app)
-- Koo Lab — [Vercel](https://papertrail-xi.vercel.app/koolab/) · [GitHub Pages](https://bschilder.github.io/PaperTrail/koolab/)
-- Standard Model Bio — [Vercel](https://papertrail-xi.vercel.app/standardmodelbio/) · [GitHub Pages](https://bschilder.github.io/PaperTrail/standardmodelbio/)
+- **Landing page** (lab picker): [papertrail-portal.vercel.app](https://papertrail-portal.vercel.app)
+- Koo Lab — [Vercel](https://papertrail-portal.vercel.app/koolab/) · [GitHub Pages](https://bschilder.github.io/PaperTrail/koolab/)
+- Standard Model Bio — [Vercel](https://papertrail-portal.vercel.app/standardmodelbio/) · [GitHub Pages](https://bschilder.github.io/PaperTrail/standardmodelbio/)
 
 - **GitHub**: [bschilder/PaperTrail](https://github.com/bschilder/PaperTrail)
 - **PyPI**: [papertrail-lab](https://pypi.org/project/papertrail-lab/)


### PR DESCRIPTION
papertrail.vercel.app is globally taken (hence the auto -xi suffix). Added papertrail-portal.vercel.app as a project production domain (public + auto-tracking) and updated README/docs links.